### PR TITLE
Laser frame no longer needs to be same as base frame

### DIFF
--- a/slam_toolbox/config/mapper_params_online_sync.yaml
+++ b/slam_toolbox/config/mapper_params_online_sync.yaml
@@ -10,7 +10,6 @@ ceres_loss_function: None
 map_frame: map
 odom_frames: ["robot1/odom", "robot2/odom"]
 base_frames: ["robot1/base_footprint", "robot2/base_footprint"]
-laser_frames: ["robot1/laser_frame", "robot2/laser_frame"]
 laser_topics: ["/robot1/scan", "/robot2/scan"]
 mode: mapping #localization
 

--- a/slam_toolbox/config/mapper_params_online_sync.yaml
+++ b/slam_toolbox/config/mapper_params_online_sync.yaml
@@ -10,6 +10,7 @@ ceres_loss_function: None
 map_frame: map
 odom_frames: ["robot1/odom", "robot2/odom"]
 base_frames: ["robot1/base_footprint", "robot2/base_footprint"]
+laser_frames: ["robot1/laser_frame", "robot2/laser_frame"]
 laser_topics: ["/robot1/scan", "/robot2/scan"]
 mode: mapping #localization
 

--- a/slam_toolbox/include/slam_toolbox/experimental/slam_toolbox_lifelong.hpp
+++ b/slam_toolbox/include/slam_toolbox/experimental/slam_toolbox_lifelong.hpp
@@ -42,7 +42,7 @@ public:
 
 protected:
   virtual void laserCallback(
-    const sensor_msgs::LaserScan::ConstPtr& scan) override final;
+    const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) override final;
   virtual bool deserializePoseGraphCallback(
     slam_toolbox_msgs::DeserializePoseGraph::Request& req,
     slam_toolbox_msgs::DeserializePoseGraph::Response& resp) override final;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_async.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_async.hpp
@@ -33,7 +33,7 @@ public:
 
 protected:
   virtual void laserCallback(
-    const sensor_msgs::LaserScan::ConstPtr& scan) override final;
+    const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) override final;
   virtual bool deserializePoseGraphCallback(
     slam_toolbox_msgs::DeserializePoseGraph::Request& req,
     slam_toolbox_msgs::DeserializePoseGraph::Response& resp) override final;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -134,7 +134,7 @@ protected:
 
   // Internal state
   std::vector<std::unique_ptr<boost::thread> > threads_;
-  boost::mutex map_to_odom_mutex_, smapper_mutex_, pose_mutex_;
+  boost::mutex map_to_odom_mutex_, smapper_mutex_, pose_mutex_, laser_id_map_mutex_;
   PausedState state_;
   nav_msgs::GetMap::Response map_;
   ProcessType processor_type_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -70,7 +70,7 @@ protected:
   void setROSInterfaces(ros::NodeHandle& node);
 
   // callbacks
-  virtual void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan) = 0;
+  virtual void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) = 0;
   bool mapCallback(nav_msgs::GetMap::Request& req,
     nav_msgs::GetMap::Response& res);
   virtual bool serializePoseGraphCallback(slam_toolbox_msgs::SerializePoseGraph::Request& req,
@@ -111,7 +111,7 @@ protected:
 
   // Storage for ROS parameters
   std::string map_frame_, map_name_;
-  std::vector<std::string> odom_frames_, base_frames_, laser_frames_, laser_topics_;
+  std::vector<std::string> odom_frames_, base_frames_, laser_topics_;
   ros::Duration transform_timeout_, tf_buffer_dur_, minimum_time_interval_;
   int throttle_scans_;
 
@@ -123,8 +123,7 @@ protected:
   std::unique_ptr<karto::Dataset> dataset_;
   std::map<std::string, laser_utils::LaserMetadata> lasers_;
   std::map<std::string, tf2::Transform> m_map_to_odoms_;
-  std::map<std::string, std::string> m_base_id_to_odom_id_;
-  std::map<std::string, std::string> m_laser_id_to_base_id_;
+  std::map<std::string, std::string> m_base_id_to_odom_id_, m_laser_id_to_base_id_;
 
   // helpers
   std::map<std::string,std::unique_ptr<laser_utils::LaserAssistant>> laser_assistants_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_common.hpp
@@ -111,7 +111,7 @@ protected:
 
   // Storage for ROS parameters
   std::string map_frame_, map_name_;
-  std::vector<std::string> odom_frames_, base_frames_, laser_topics_;
+  std::vector<std::string> odom_frames_, base_frames_, laser_frames_, laser_topics_;
   ros::Duration transform_timeout_, tf_buffer_dur_, minimum_time_interval_;
   int throttle_scans_;
 
@@ -124,6 +124,7 @@ protected:
   std::map<std::string, laser_utils::LaserMetadata> lasers_;
   std::map<std::string, tf2::Transform> m_map_to_odoms_;
   std::map<std::string, std::string> m_base_id_to_odom_id_;
+  std::map<std::string, std::string> m_laser_id_to_base_id_;
 
   // helpers
   std::map<std::string,std::unique_ptr<laser_utils::LaserAssistant>> laser_assistants_;

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_localization.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_localization.hpp
@@ -35,7 +35,7 @@ public:
 
 protected:
   virtual void laserCallback(
-    const sensor_msgs::LaserScan::ConstPtr& scan) override final;
+    const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) override final;
   void localizePoseCallback(
     const geometry_msgs::PoseWithCovarianceStampedConstPtr& msg);
 

--- a/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
+++ b/slam_toolbox/include/slam_toolbox/slam_toolbox_sync.hpp
@@ -33,7 +33,7 @@ public:
   void run();
 
 protected:
-  virtual void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan) override final;
+  virtual void laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id) override final;
   bool clearQueueCallback(slam_toolbox_msgs::ClearQueue::Request& req, slam_toolbox_msgs::ClearQueue::Response& resp);
   virtual bool deserializePoseGraphCallback(slam_toolbox_msgs::DeserializePoseGraph::Request& req,
     slam_toolbox_msgs::DeserializePoseGraph::Response& resp) override final;

--- a/slam_toolbox/src/experimental/slam_toolbox_lifelong.cpp
+++ b/slam_toolbox/src/experimental/slam_toolbox_lifelong.cpp
@@ -66,7 +66,7 @@ LifelongSlamToolbox::LifelongSlamToolbox(ros::NodeHandle& nh)
 
 /*****************************************************************************/
 void LifelongSlamToolbox::laserCallback(
-  const sensor_msgs::LaserScan::ConstPtr& scan)
+  const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id)
 /*****************************************************************************/
 {
   // no odom info on any pose helper

--- a/slam_toolbox/src/slam_toolbox_async.cpp
+++ b/slam_toolbox/src/slam_toolbox_async.cpp
@@ -32,7 +32,7 @@ AsynchronousSlamToolbox::AsynchronousSlamToolbox(ros::NodeHandle& nh)
 
 /*****************************************************************************/
 void AsynchronousSlamToolbox::laserCallback(
-  const sensor_msgs::LaserScan::ConstPtr& scan)
+  const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id)
 /*****************************************************************************/
 {
   // no odom info on any pose helper

--- a/slam_toolbox/src/slam_toolbox_async.cpp
+++ b/slam_toolbox/src/slam_toolbox_async.cpp
@@ -40,13 +40,23 @@ void AsynchronousSlamToolbox::laserCallback(
   bool found_odom = false;
   for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
-    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
+    // try compute odometry
+    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, base_frame_id);
     if(found_odom)
       break;
   }
   if(!found_odom)
     return;
 
+  // Add new sensor to laser ID map, and to laser assistants
+  {
+    boost::mutex::scoped_lock l(laser_id_map_mutex_);
+    if(m_laser_id_to_base_id_.find(scan->header.frame_id) == m_laser_id_to_base_id_.end())
+    {
+      m_laser_id_to_base_id_[scan->header.frame_id] = base_frame_id;
+      laser_assistants_[scan->header.frame_id] = std::make_unique<laser_utils::LaserAssistant>(nh_, tf_.get(), base_frame_id);
+    }
+  }
   // ensure the laser can be used
   karto::LaserRangeFinder* laser = getLaser(scan);
 

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -59,7 +59,7 @@ SlamToolbox::SlamToolbox(ros::NodeHandle& nh)
   for(size_t idx = 0; idx < base_frames_.size(); idx++)
   {
     pose_helpers_.push_back(std::make_unique<pose_utils::GetPoseHelper>(tf_.get(), base_frames_[idx], odom_frames_[idx]));
-    laser_assistants_[base_frames_[idx]] = std::make_unique<laser_utils::LaserAssistant>(nh_, tf_.get(), base_frames_[idx]);
+    laser_assistants_[laser_frames_[idx]] = std::make_unique<laser_utils::LaserAssistant>(nh_, tf_.get(), base_frames_[idx]);
   }
   scan_holder_ = std::make_unique<laser_utils::ScanHolder>(lasers_);
   map_saver_ = std::make_unique<map_saver::MapSaver>(nh_, map_name_);
@@ -341,7 +341,7 @@ karto::LaserRangeFinder* SlamToolbox::getLaser(const
 /*****************************************************************************/
 {
   // Use laser scan ID to get base frame ID
-  const std::string& frame = m_laser_id_to_base_id_[scan->header.frame_id];
+  const std::string& frame = scan->header.frame_id;
   if(lasers_.find(frame) == lasers_.end())
   {
     try

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -385,7 +385,11 @@ tf2::Stamped<tf2::Transform> SlamToolbox::setTransformFromPoses(
 /*****************************************************************************/
 {
   // Use laser frame to look up base and odom frame
-  const std::string& base_frame = m_laser_id_to_base_id_[header.frame_id];
+  std::string base_frame;
+  {
+    boost::mutex::scoped_lock l(laser_id_map_mutex_);
+    base_frame = m_laser_id_to_base_id_[header.frame_id];
+  }
   const std::string& odom_frame = m_base_id_to_odom_id_[base_frame];
   // Compute the map->odom transform
   const ros::Time& t = header.stamp;

--- a/slam_toolbox/src/slam_toolbox_common.cpp
+++ b/slam_toolbox/src/slam_toolbox_common.cpp
@@ -396,8 +396,8 @@ tf2::Stamped<tf2::Transform> SlamToolbox::setTransformFromPoses(
 /*****************************************************************************/
 {
   // Use laser frame to look up base and odom frame
-  const std::string base_frame = m_laser_id_to_base_id_[header.frame_id];
-  const std::string odom_frame = m_base_id_to_odom_id_[base_frame];
+  const std::string& base_frame = m_laser_id_to_base_id_[header.frame_id];
+  const std::string& odom_frame = m_base_id_to_odom_id_[base_frame];
   // Compute the map->odom transform
   const ros::Time& t = header.stamp;
   tf2::Stamped<tf2::Transform> odom_to_map;

--- a/slam_toolbox/src/slam_toolbox_localization.cpp
+++ b/slam_toolbox/src/slam_toolbox_localization.cpp
@@ -101,7 +101,7 @@ bool LocalizationSlamToolbox::deserializePoseGraphCallback(
 
 /*****************************************************************************/
 void LocalizationSlamToolbox::laserCallback(
-  const sensor_msgs::LaserScan::ConstPtr& scan)
+  const sensor_msgs::LaserScan::ConstPtr& scan, const std::string& base_frame_id)
 /*****************************************************************************/
 {
 // no odom info on any pose helper

--- a/slam_toolbox/src/slam_toolbox_sync.cpp
+++ b/slam_toolbox/src/slam_toolbox_sync.cpp
@@ -73,7 +73,9 @@ void SynchronousSlamToolbox::laserCallback(
   bool found_odom = false;
   for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
-    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, scan->header.frame_id);
+    // Get base frame ID from laser frame ID, then try compute odometry
+    const std::string base_frame_id = m_laser_id_to_base_id_[scan->header.frame_id];
+    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, base_frame_id); // Assumes base frame = laser frame; nvm
     if(found_odom)
       break;
   }

--- a/slam_toolbox/src/slam_toolbox_sync.cpp
+++ b/slam_toolbox/src/slam_toolbox_sync.cpp
@@ -74,7 +74,7 @@ void SynchronousSlamToolbox::laserCallback(
   for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
     // Get base frame ID from laser frame ID, then try compute odometry
-    const std::string base_frame_id = m_laser_id_to_base_id_[scan->header.frame_id];
+    const std::string& base_frame_id = m_laser_id_to_base_id_[scan->header.frame_id];
     found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, base_frame_id); // Assumes base frame = laser frame; nvm
     if(found_odom)
       break;

--- a/slam_toolbox/src/slam_toolbox_sync.cpp
+++ b/slam_toolbox/src/slam_toolbox_sync.cpp
@@ -81,13 +81,15 @@ void SynchronousSlamToolbox::laserCallback(
   if(!found_odom)
     return;
   
-  // Add new sensor to ID map, and to laser assistants
-  if(m_laser_id_to_base_id_.find(scan->header.frame_id) == m_laser_id_to_base_id_.end())
+  // Add new sensor to laser ID map, and to laser assistants
   {
-    m_laser_id_to_base_id_[scan->header.frame_id] = base_frame_id;
-    laser_assistants_[scan->header.frame_id] = std::make_unique<laser_utils::LaserAssistant>(nh_, tf_.get(), base_frame_id);
+    boost::mutex::scoped_lock l(laser_id_map_mutex_);
+    if(m_laser_id_to_base_id_.find(scan->header.frame_id) == m_laser_id_to_base_id_.end())
+    {
+      m_laser_id_to_base_id_[scan->header.frame_id] = base_frame_id;
+      laser_assistants_[scan->header.frame_id] = std::make_unique<laser_utils::LaserAssistant>(nh_, tf_.get(), base_frame_id);
+    }
   }
-
   // ensure the laser can be used
   karto::LaserRangeFinder* laser = getLaser(scan);
 

--- a/slam_toolbox/src/slam_toolbox_sync.cpp
+++ b/slam_toolbox/src/slam_toolbox_sync.cpp
@@ -74,13 +74,13 @@ void SynchronousSlamToolbox::laserCallback(
   for(size_t idx = 0; idx < pose_helpers_.size(); idx++)
   {
     // try compute odometry
-    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, base_frame_id); // Assumes base frame = laser frame; nvm
+    found_odom = pose_helpers_[idx]->getOdomPose(pose, scan->header.stamp, base_frame_id);
     if(found_odom)
       break;
   }
   if(!found_odom)
     return;
-  
+
   // Add new sensor to laser ID map, and to laser assistants
   {
     boost::mutex::scoped_lock l(laser_id_map_mutex_);


### PR DESCRIPTION
Previously, laser frames had to be same as base frames for each robot. This meant the two frames had to be identical in pose and name. This is no longer the case. Laser frame names are retrieved from laser scan topics, and the `\tf` topic must publish transform from base frame to laser frame for each robot.